### PR TITLE
Code Cleanup from Raising The Bar E04

### DIFF
--- a/LateboundConstantGenerator/Extensions.cs
+++ b/LateboundConstantGenerator/Extensions.cs
@@ -1,14 +1,29 @@
 ﻿
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.Xrm.Sdk.Metadata;
 
 namespace Rappen.XTB.LCG
 {
     public static class Extensions
     {
+        public static AttributeMetadata GetAttribute(this Dictionary<string, EntityMetadata> entities, string entity, string attribute)
+        {
+            if (entities == null
+                || !entities.TryGetValue(entity, out var metadata)
+                || metadata.Attributes == null)
+            {
+                return null;
+            }
+
+            return metadata.Attributes.FirstOrDefault(metaattribute => metaattribute.LogicalName == attribute);
+        }
+
+
         public static void WriteFile(this string content, string filename, string orgurl, Settings settings)
         {
             content = content.BeautifyContent();

--- a/LateboundConstantGenerator/LogUsage.cs
+++ b/LateboundConstantGenerator/LogUsage.cs
@@ -13,9 +13,16 @@ namespace Rappen.XTB.LCG
 
         public static async Task DoLog(string action)
         {
+#pragma warning disable 162
 #if DEBUG
             return;
 #endif
+            await DoLogSafe(action);
+#pragma warning restore 162
+        }
+
+        private static async Task DoLogSafe(string action)
+        {
             try
             {
                 var ass = Assembly.GetExecutingAssembly().GetName();
@@ -23,13 +30,13 @@ namespace Rappen.XTB.LCG
                 var name = ass.Name.Replace(" ", "");
                 action = "LCG-" + action;
 
-                var query = "t.php" +
-                    "?sc_project=10396418" +
-                    "&security=95f631d9" +
-                    "&java=1" +
-                    "&invisible=1" +
-                    "&u={2}" +
-                    "&camefrom={0} {1}";
+                const string query = "t.php" +
+                                     "?sc_project=10396418" +
+                                     "&security=95f631d9" +
+                                     "&java=1" +
+                                     "&invisible=1" +
+                                     "&u={2}" +
+                                     "&camefrom={0} {1}";
 
                 using (var client = new HttpClient())
                 {
@@ -39,11 +46,14 @@ namespace Rappen.XTB.LCG
                     response.EnsureSuccessStatusCode();
                     if (response.IsSuccessStatusCode)
                     {
-                        response.Content.ReadAsStringAsync();
+                        var keepGoing = response.Content.ReadAsStringAsync();
                     }
                 }
             }
-            catch { }
+            catch
+            {
+                // Ok Not to throw an execption because this is attempt to log something
+            }
         }
 
         #endregion Public Methods


### PR DESCRIPTION
AppInsights
- Removed Compiler Warning

Extensions.cs
- Added call to get an attribute from an entity Dictionary

LCG
- Handled Multiple Enumerations
- Used "is" notation to simplify if statements
- Split filters into their logical parts

LogUsage
- Removed Compiler Warnings

MetadataHelper
- Sorted fields